### PR TITLE
Fix units of hamacker constant

### DIFF
--- a/syfos/gui/default_parameters.py
+++ b/syfos/gui/default_parameters.py
@@ -43,7 +43,7 @@ parameterInputsProbe = {
 		"formulaCharacterSubscript": "tip",
 		"placeholder": "1 - 450",
 		"valueBoundaries": [1e-21, 450e-21],
-		"unitLabel": "zJ"
+		"unitLabel": "J"
 	},
 	"springConstant": {
 		"label": "",
@@ -85,7 +85,7 @@ parameterInputsSample = {
 		"formulaCharacterSubscript": "sample",
 		"placeholder": "1 - 450",
 		"valueBoundaries": [1e-21, 450e-21],
-		"unitLabel": "zJ"
+		"unitLabel": "J"
 	}
 }
 parameterInputsExperiment = {


### PR DESCRIPTION
Change displayed units from zJ to J since the numerical values are given in J (e,g, for SiO2  as 66*10^(-21) J) .